### PR TITLE
Rob/add explicit watch and ignore patterns

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -28,12 +28,12 @@ func Run(paths []string, gitClient *git.Client, workers int, defaults *freshness
 	// Phase 1: Parse all documents in parallel
 	parsedDocs := parseAllDocs(paths, workers)
 
-	// Phase 2: Build FileChangeIndex for all docs (all strategies check for code changes)
+	// Phase 2: Build FileChangeIndex for code_changes strategy docs only
 	var index *git.FileChangeIndex
 	var repoRoot string
 	if gitClient != nil {
 		repoRoot = gitClient.RepoRoot()
-		oldestDate := findOldestLastReviewedDate(parsedDocs)
+		oldestDate := findOldestCodeChangesDate(parsedDocs)
 		if !oldestDate.IsZero() {
 			// Build index starting from oldest date to minimize git output
 			var err error
@@ -84,14 +84,19 @@ func parseAllDocs(paths []string, workers int) []parsedDoc {
 	return parsed
 }
 
-// findOldestLastReviewedDate finds the oldest last_reviewed date among all docs
-// with freshness configuration. Returns zero time if none found.
-// All strategies check for code changes, so we need the oldest date across all docs.
-func findOldestLastReviewedDate(docs []parsedDoc) time.Time {
+// findOldestCodeChangesDate finds the oldest last_reviewed date among docs
+// using the code_changes strategy. Returns zero time if none found.
+// Only code_changes strategy needs git history, so we scope the index accordingly.
+func findOldestCodeChangesDate(docs []parsedDoc) time.Time {
 	var oldest time.Time
 
 	for _, pd := range docs {
 		if pd.err != nil || pd.doc == nil || pd.doc.Freshness == nil {
+			continue
+		}
+
+		// Only consider docs using code_changes strategy
+		if pd.doc.Freshness.Strategy != "code_changes" {
 			continue
 		}
 

--- a/internal/freshness/checker.go
+++ b/internal/freshness/checker.go
@@ -120,7 +120,7 @@ func (c *Checker) Check(doc *document.Document) Result {
 }
 
 // CheckWithIndex checks a document using an optional precomputed FileChangeIndex.
-// All strategies check for code changes in addition to their primary logic.
+// Only the code_changes strategy uses the index; other strategies ignore it.
 // Using an index avoids individual git calls for code change detection.
 func (c *Checker) CheckWithIndex(doc *document.Document, index *git.FileChangeIndex) Result {
 	result := Result{


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds explicit watch and ignore patterns for document freshness, a new files command to list a doc’s domain, and support for checking specific files or directories. This gives precise control over which code changes mark docs stale, with smart defaults, safer git root detection, and consolidated CI issue reporting.

- **New Features**
  - Support watch and ignore patterns in frontmatter for code_changes.
  - Smart defaults from doc location: watch parent subsystem, ignore docs dir.
  - Merge config defaults (.docrot.yml) with frontmatter; frontmatter wins. If only one side is set, inherit the other from config. If neither, use config or smart defaults.
  - New files command: lists matched files for a doc (text or JSON).
  - Check output now lists all changed files for stale docs; check accepts files or directories and derives the git root from inputs (errors on mixed repos).
  - Added project .docrot.yml and updated docs frontmatter.
  - GitHub workflow builds from source and opens a single consolidated issue for stale docs.

- **Bug Fixes**
  - Use start of next day for code_changes comparisons to avoid timezone edge cases.
  - Handle malformed glob patterns without silent errors.
  - Git index and change detection now honor ignore patterns.

<sup>Written for commit 246e788a6fe082db321ef52f601a34316733146b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

