### PR TITLE
docs: add badges section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,3 +189,7 @@ Use `--format json` for machine-readable output:
 | 1 | One or more docs are stale |
 | 2 | Configuration or usage error |
 
+
+## Badges
+
+[![Go Report Card](https://goreportcard.com/badge/github.com/andimrob/docrot)](https://goreportcard.com/report/github.com/andimrob/docrot)


### PR DESCRIPTION
## Summary

Add a Badges section to the README with a Go Report Card badge linking to the project's goreportcard.com page.

## Changes

- Added a new "Badges" section at the end of README.md with a Go Report Card badge

## Test plan

- [ ] Badge link renders correctly in GitHub markdown
- [ ] Badge URL resolves to the correct goreportcard.com page

## Notes

Documentation-only change, no code modifications.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Badges section to the README with a Go Report Card badge linking to this repo’s report on goreportcard.com to surface code quality at a glance.

<sup>Written for commit d9a4b3506f5341d3af5b39d2d06205cc9b63a17e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

